### PR TITLE
Changed hazy weather to not windyable

### DIFF
--- a/model-ajstewart.js
+++ b/model-ajstewart.js
@@ -93,13 +93,11 @@ const weatherMap = ({
   },
   hazysunshine: {
     dominant: 'cloudy',
-    superficial: {},
-    windyable: true
+    superficial: {}
   },
   hazymoonlight: {
     dominant: 'cloudy',
-    superficial: {},
-    windyable: true
+    superficial: {}
   },
   dreary: {
     dominant: 'cloudy',


### PR DESCRIPTION
`hazysunshine` and `hazymoonlight` are no longer windyable given evidence presented in #6.

Fixes #6.